### PR TITLE
Updated 03 example. Small changes observed after 03 example reproduction.

### DIFF
--- a/03-aws-localstack/README.md
+++ b/03-aws-localstack/README.md
@@ -89,7 +89,7 @@ Since the first stage requires us not to create any other resources
 apart from the ones required for storing the state or its lock we need
 to modify `main.tf` temporarily by commenting the blocks that start with
 ```
-resource "aws_s3_bucket" "test-bucket" {
+resource "aws_s3_bucket" "main-bucket" {
 ```
 and 
 ```
@@ -121,11 +121,6 @@ be enough for some AWS CLI subcommands (such as `dynamodb`), while
 others (like `s3`) might work even when profile is not switched to
 `localstack`. 
 
-Since `s3://tf-state` bucket we create have versions enabled it should
-be possible to watch all versions of the state via 
-```
-awsl s3api list-object-versions --bucket tf-state
-```
 Now, once monitoring is started (and assuming LocalStack is started)
 we can run the following commands:
 ```
@@ -156,6 +151,11 @@ Terraform will ask us if it is ok to move the state to S3, we should say
 longer needed and we can safely remove it
 ```
 rm ./terraform.tfstate
+```
+Since `s3://tf-state` bucket we create have versions enabled it should
+be possible to watch all versions of the state via 
+```
+awsl s3api list-object-versions --bucket tf-state
 ```
 ## Create the main set of resources
 via uncommenting the block the starts with
@@ -214,9 +214,9 @@ terraform apply
 After these commands our terminal-based monitoring (that one we started
 above via `watch`) should show us
 - three AWS S3 buckets
-  - `tf-state`
-  - `app/tf-state`
-  - `db/tf-state`
+  - `terraform.tfstate`
+  - `app/terraform.tfstate`
+  - `db/terraform.tfstate`
 - single DynamoDB table `terraform-lock`
 
 The reason we have a single table for all the modules is because we can
@@ -228,9 +228,6 @@ awsl dynamodb scan --table-name terraform-lock
 command.
 
 
-```
-awsl dynamodb scan --table-name terraform-lock
-```
 
 ## References
 ### Modules

--- a/03-aws-localstack/README.md
+++ b/03-aws-localstack/README.md
@@ -214,9 +214,9 @@ terraform apply
 After these commands our terminal-based monitoring (that one we started
 above via `watch`) should show us
 - three AWS S3 buckets
-  - `terraform.tfstate`
-  - `app/terraform.tfstate`
-  - `db/terraform.tfstate`
+  - `tf-state`
+  - `app/tf-state`
+  - `db/tf-state`
 - single DynamoDB table `terraform-lock`
 
 The reason we have a single table for all the modules is because we can


### PR DESCRIPTION
Line 92 before: resource "aws_s3_bucket" "test-bucket"
Line 92 modified to: resource "aws_s3_bucket" "test-bucket"

Lines 155 -159. Comand moved to "Moving Terraform state to AWS S3" section.
awsl s3api list-object-versions --bucket tf-state

Lines 217 - 219 before
  - `tf-state`
  - `app/tf-state`
  - `db/tf-state`

Lines 217 - 219 modified to:
  - `terraform.tfstate`
  - `app/terraform.tfstate`
  - `db/terraform.tfstate`

Lines 231 -233. Typo. Removed duplicate command
awsl dynamodb scan --table-name terraform-lock